### PR TITLE
Basic peer communication

### DIFF
--- a/client.py
+++ b/client.py
@@ -54,44 +54,46 @@ def connect_peers():
     for peer in peer_list:   
         p_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         p_socket.setblocking(False)
-        peer_sockets.append(p_socket)
-        try:
-            if p_socket.connect_ex(peer) == 0:
-                p_socket.append(p_socket)
-        except Exception as e:
-            print('exception', e)
+        errcode = p_socket.connect_ex(peer)
+        
+        if errcode == 115: #connection in progress     
+            connecting.append(p_socket)
+        elif errcode == 0: #connected
+            connected.append(p_socket)
 
 def send_handshake(peer_socket):
     HANDSHAKE = b'\x13BitTorrent protocol\x00\x00\x00\x00\x00\x00\x00\x00'
     msg = HANDSHAKE + torrent_file.info_hash + peer_id.encode()
-
-    peer_socket.setblocking(True)
     peer_socket.sendall(msg)
-    data = peer_socket.recv(1024)
 
+    data = peer_socket.recv(1024)
     #print("received:", data)
     print("received handshake")
 
 def run():
     while True:
         try:
-            readable, writable, exceptions = select.select([], peer_sockets, [])
+            readable, writable, exceptions = select.select([], connecting, [])
 
             for sock in writable:
-                if sock.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR) == 0:
-                    send_handshake(sock)
-                    peer_sockets.remove(sock)
-                    connected.append(sock)
-                    print("{} connected: {}".format(len(connected), sock))
-                else:
-                    peer_sockets.remove(sock)
+                if sock in connecting:
+                    if sock.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR) == 0:
+                    
+                        sock.setblocking(True)
+                        connecting.remove(sock)
+                        connected.append(sock)
+                        send_handshake(sock)
+
+                        print("{} connected: {}".format(len(connected), sock))
+                    else:
+                        connecting.remove(sock)
         except Exception as e:
             print('exception', e)
 
-peer_sockets = []
+connecting = []
 connected = []
 
-torrent_file = torrent.Torrent('bl.torrent')
+torrent_file = torrent.Torrent('mint.torrent')
 peer_id = generate_peer_id()
 tracker_response = tracker_request()
 print(tracker_response)

--- a/client.py
+++ b/client.py
@@ -65,31 +65,37 @@ def send_handshake(peer_socket):
     HANDSHAKE = b'\x13BitTorrent protocol\x00\x00\x00\x00\x00\x00\x00\x00'
     msg = HANDSHAKE + torrent_file.info_hash + peer_id.encode()
     peer_socket.sendall(msg)
-
-    data = peer_socket.recv(1024)
+    #data = peer_socket.recv(1024)
     #print("received:", data)
-    print("received handshake")
+    #print("received handshake")
+
+def recieve_message(peer_socket):
+    data = peer_socket.recv(1024)
+    if data:
+        print("message receieved")
 
 def run():
     while True:
         try:
-            readable, writable, exceptions = select.select([], connecting, [])
+            readable, writable, exceptions = select.select(connected, connecting, [])
+
+            for sock in readable:
+                recieve_message(sock)
 
             for sock in writable:
                 if sock in connecting:
                     if sock.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR) == 0:
-                    
                         sock.setblocking(True)
                         connecting.remove(sock)
                         connected.append(sock)
                         send_handshake(sock)
-
                         print("{} connected: {}".format(len(connected), sock))
                     else:
                         connecting.remove(sock)
+
         except Exception as e:
             print('exception', e)
-
+            
 connecting = []
 connected = []
 

--- a/client.py
+++ b/client.py
@@ -2,8 +2,10 @@ import torrent
 import random
 import requests
 import bdecode
+import socket
+import select
 
-PORT = 6881
+LISTEN_PORT = 7000
 
 #20 bytes: 2 for client id, 4 for version number, remaining are random integers
 def generate_peer_id():
@@ -16,7 +18,7 @@ def tracker_request():
     params = {
         'info_hash': torrent_file.info_hash,
         'peer_id': peer_id,
-        'port': PORT,
+        'port': LISTEN_PORT,
         'uploaded': 0,
         'downloaded': 0,
         'left': torrent_file.length,
@@ -25,27 +27,80 @@ def tracker_request():
     }
 
     url = torrent_file.data['announce']
+        
     response = requests.get(url, params)
+
     return bdecode.decode(response.content)
 
 #TODO: check for compact vs non-compact peer list
 def decode_compact_peer_list(peer_bytes):
-
     peer_list = []
     for x in range(0, len(peer_bytes), 6):
         ip = '.'.join(str(x) for x in peer_bytes[x:x+4]) #first 4 bytes are ip
         port = int.from_bytes(peer_bytes[x+4:x+6], byteorder='big') #last 2 bytes together are port
-        peer_list.append('{}:{}'.format(ip, port))
+        peer_list.append((ip, port)) 
 
     return peer_list
 
+def connect_peers():
+    for peer in peer_list:   
+        p_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        p_socket.setblocking(False)
+        peer_sockets.append(p_socket)
+        try:
+            if p_socket.connect_ex(peer) == 0:
+                p_socket.append(p_socket)
+        except Exception as e:
+            print('exception', e)
+
+def send_handshake(peer_socket):
+    HANDSHAKE = b'\x13BitTorrent protocol\x00\x00\x00\x00\x00\x00\x00\x00'
+    msg = HANDSHAKE + torrent_file.info_hash + peer_id.encode()
+
+    peer_socket.setblocking(True)
+    peer_socket.sendall(msg)
+    data = peer_socket.recv(1024)
+
+    print("received:", data)
+
+def run():
+    while True:
+        try:
+            readable, writable, exceptions = select.select(
+                [],
+                peer_sockets,
+                []
+            )
+
+            for sock in writable:
+                if sock.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR) == 0:
+                    send_handshake(sock)
+                    peer_sockets.remove(sock)
+                    connected.append(sock)
+                    print("CONNECTIONS:", len(connected))
+                else:
+                    peer_sockets.remove(sock)
+        except Exception as e:
+            print('exception', e)
 
 
-torrent_file = torrent.Torrent('oz.torrent')
+peer_sockets = []
+connected = []
+
+torrent_file = torrent.Torrent('o.torrent')
 peer_id = generate_peer_id()
 tracker_response = tracker_request()
 
 print(tracker_response)
-print(decode_compact_peer_list(tracker_response['peers']))
+
+peer_list = decode_compact_peer_list(tracker_response['peers'])
+print(peer_list)
+
+connect_peers()
+run()
+
+
+
+
 
 

--- a/client.py
+++ b/client.py
@@ -103,7 +103,7 @@ def receive_piece(peer, msg_len):
     begin = int.from_bytes(peer.buffer[9:13], byteorder='big')
     block = peer.buffer[13:13+msg_len]
 
-    print("RECIEVED - PIECE:{} BLOCK:{}".format(index, int(begin/BLOCK_SIZE)))
+    #print("RECIEVED - PIECE:{} BLOCK:{}".format(index, int(begin/BLOCK_SIZE)))
 
     byte_offset =  index*torrent_file.data['info']['piece length'] + begin
     fp_out.seek(byte_offset, 0)
@@ -141,7 +141,7 @@ def receive_handshake(peer):
     if len(peer.buffer) >= 68:
         if peer.buffer[0:20] == b'\x13BitTorrent protocol' and peer.buffer[28:48] == torrent_file.info_hash:
             print("RECEIVED: HANDSHAKE")
-            print(peer.buffer[0:68])
+            #print(peer.buffer[0:68])
             peer.handshake = True
             peer.buffer = peer.buffer[68:]
         else:
@@ -166,7 +166,7 @@ def send_message(peer_socket):
         send_request(peer, peer_socket)
         peer.request = True
         
-    elif not peer.am_interested: #check here if a peer has piece we are interested in
+    elif not peer.am_interested: #TODO: check if peer has piece we are interested in
         print("SENDING INTERESTED")
         peer_socket.sendall(b'\x00\x00\x00\x01\x02')
         peer.am_interested = True
@@ -206,7 +206,7 @@ def send_request(peer, peer_socket):
     
 def select_block(peer):
 
-    for piece_index in range(torrent_file.num_pieces-1,torrent_file.num_pieces):#range(torrent_file.num_pieces): 
+    for piece_index in range(torrent_file.num_pieces): 
 
         find_block = blocks_requested[piece_index].find('0b0')
     

--- a/client.py
+++ b/client.py
@@ -64,29 +64,55 @@ def send_handshake(peer_socket):
     HANDSHAKE = b'\x13BitTorrent protocol\x00\x00\x00\x00\x00\x00\x00\x00'
     msg = HANDSHAKE + torrent_file.info_hash + peer_id.encode()
     peer_socket.sendall(msg)
-    #data = peer_socket.recv(1024)
-    #print("received:", data)
-    #print("received handshake")
 
-def recieve_message(peer_socket):
-    data = peer_socket.recv(1024)
+def recieve_message(data, peer_socket):
+    #get peer object from list
+    peer_ip = peer_socket.getpeername()
+    peer = peer_list[peer_list.index(peer_ip)] 
+    peer.buffer += data
 
-    if data:
-        #get peer object from list
-        peer_ip = peer_socket.getpeername()
-        peer = peer_list[peer_list.index(peer_ip)] 
-
-        print("message receieved")
+    if peer.handshake == False:
+        recieve_handshake(peer)
     else:
-        connected.remove(peer_socket)
+        message_id = peer.buffer[4]
+        if message_id == 5:
+            recieve_bitfield(peer)
+        else:
+            print("RECEIVED MESSAGE ID: ", message_id)
 
+def recieve_handshake(peer):
+    if len(peer.buffer) >= 68:
+        if peer.buffer[0:20] == b'\x13BitTorrent protocol' and peer.buffer[28:48] == torrent_file.info_hash:
+            print(peer.buffer[0:68])
+            print("RECEIVED: HANDSHAKE")
+            peer.handshake = True
+            peer.buffer = peer.buffer[68:]
+        else:
+            print("invalid peer handshake, dropping connection")
+
+def recieve_bitfield(peer):
+    bitfield_length = int.from_bytes(peer.buffer[0:4], byteorder='big')
+    print("BITFIELD LENGTH: ", bitfield_length)
+    if len(peer.buffer) > bitfield_length:
+        bitfield = peer.buffer[5:bitfield_length]
+
+        print(bitfield)
+        print("RECIEVED: BITFIELD")
+
+        print(len(bitfield)*8)
+        peer.buffer = peer.buffer[bitfield_length:]
+        
 def run():
     while True:
         try:
             readable, writable, exceptions = select.select(connected, connecting, [])
 
             for sock in readable:
-                    recieve_message(sock)
+                data = sock.recv(8192)
+                if data:
+                    recieve_message(data, sock)
+                else:
+                    connected.remove(sock)
 
             for sock in writable:
                 if sock in connecting:
@@ -96,17 +122,24 @@ def run():
                         connected.append(sock)
                         send_handshake(sock)
                         print("{} connected: {}".format(len(connected), sock))
+
+                        #connecting.clear() #TESTING, REMOVE ME
                     else:
                         connecting.remove(sock)
 
         except Exception as e:
             print('exception', e)
 
+
 class Peer:
     def __init__(self, ip, port):
         self.address = (ip, port)
+        self.handshake = False
+        self.buffer = b''
+
     def __eq__(self, obj):
         return self.address == obj
+
 
 peer_list = []
 
@@ -115,6 +148,7 @@ connected = []
 
 torrent_file = torrent.Torrent('mint.torrent')
 peer_id = generate_peer_id()
+
 tracker_response = tracker_request()
 print(tracker_response)
 
@@ -126,6 +160,9 @@ print()
 
 connect_peers()
 run()
+
+
+
 
 
 

--- a/torrent.py
+++ b/torrent.py
@@ -1,12 +1,14 @@
 import bencodepy
 import hashlib
 import bdecode
+import math
 
 #class representing a torrent file
 class Torrent:
     def __init__(self, filename):
         self.data = {}
         self.length = 0
+        self.num_pieces = 0
         self.info_hash = None
         self.read_torrent(filename)
     
@@ -24,6 +26,9 @@ class Torrent:
             self.length = self.get_total_length()
         else:
             self.length = self.data['info']['length']
+
+        self.num_pieces = math.ceil(self.length / self.data['info']['piece length'])
+
         
     def get_total_length(self):
         total = 0

--- a/torrent.py
+++ b/torrent.py
@@ -9,7 +9,9 @@ class Torrent:
         self.data = {}
         self.length = 0
         self.num_pieces = 0
+        self.is_multi = False
         self.info_hash = None
+
         self.read_torrent(filename)
     
     def read_torrent(self, filename):
@@ -23,14 +25,14 @@ class Torrent:
         self.info_hash = hashlib.sha1(info_bencoded).digest()
 
         if('files' in self.data['info']):
-            self.length = self.get_total_length()
+            self.is_multi = True
+            self.length = self.get_multifile_length()
         else:
             self.length = self.data['info']['length']
 
         self.num_pieces = math.ceil(self.length / self.data['info']['piece length'])
 
-        
-    def get_total_length(self):
+    def get_multifile_length(self):
         total = 0
         for file in self.data['info']['files']:
             total += file['length']


### PR DESCRIPTION
Tracker request improvements:
--------------------------------------
-retry request on failure. sometimes trackers don't accept valid requests on the first try
-urlencode request parameters using `urllib`. the request library uses `+`  for encoding spaces instead of `%20`, which is rejected by some trackers.

Peer connection:
---------------------
-handle connection with multiple peers using non-blocking `connect` and `select` loop
-handle sending/receiving messages for connected peers

Messages:
--------------
-receive handshake messages
-receive bitfield messages
-receive unchoke messages
-receive piece messages

-send handshake messages
-send interested messages
-send request messages

-use basic sequential strategy for requesting pieces
-validate incoming pieces and write to output file

Notes:
--------
current implementation can (slowly) download a complete output file given a single-file torrent. note that:
-if a request is sent but never fulfilled, the block won't be re-requested
-download is inefficient since we aren't uploading our own pieces
-currently writing to output file after every block received. can improve IO time by buffering writes
