### PR TITLE
Handle dropped connections

### DIFF
--- a/client.py
+++ b/client.py
@@ -135,7 +135,7 @@ peer_list = []
 connecting = []
 connected = []
 
-torrent = torrent.Torrent('c.torrent')
+torrent = torrent.Torrent('dataset.torrent')
 peer_id = generate_peer_id()
 
 print("FILENAME: ", torrent.data['info']['name'])

--- a/messagehandler.py
+++ b/messagehandler.py
@@ -73,7 +73,6 @@ class MessageHandler:
         #print("RECIEVED - PIECE:{} BLOCK:{}".format(index, block_index))
 
         self.file_handler.write(index, begin, block)
-        peer.request = False
         peer.requested.remove((index, block_index))
 
         if self.file_handler.bitfield[0:self.torrent.num_pieces].all(True):
@@ -114,7 +113,6 @@ class MessageHandler:
                 if piece_index == self.torrent.num_pieces-1 and block_index == self.torrent.blocks_per_final_piece-1:
                     length = self.torrent.final_piece_size - (self.torrent.blocks_per_final_piece-1)*BLOCK_SIZE
 
-                peer.request = True 
                 peer.requested.append((piece_index, block_index))
             
                 msg += b'\x00\x00\x00\x0d\x06'

--- a/messagehandler.py
+++ b/messagehandler.py
@@ -87,7 +87,7 @@ class MessageHandler:
 
         if peer.sent_handshake == False:
             self.send_handshake(peer, peer_socket)
-        elif not peer.am_interested and self.file_handler.check_interest(peer): #TODO: check if peer has piece we are interested in
+        elif not peer.am_interested and self.file_handler.check_interest(peer): 
             self.send_interested(peer, peer_socket)
         elif peer.am_interested and not peer.peer_choking and not peer.request:
             self.send_request(peer, peer_socket)
@@ -107,7 +107,7 @@ class MessageHandler:
 
             #final block may have different size
             if piece_index == self.torrent.num_pieces-1 and block_index == self.torrent.blocks_per_final_piece-1:
-                length = self.torrent.final_piece_size - (self.torrent_fileblocks_per_final_piece-1)*BLOCK_SIZE
+                length = self.torrent.final_piece_size - (self.torrent.blocks_per_final_piece-1)*BLOCK_SIZE
 
             peer.request = True 
 

--- a/peer.py
+++ b/peer.py
@@ -4,12 +4,14 @@ import bitstring
 class Peer:
     def __init__(self, ip, port, torrent):
         self.address = (ip, port)
-
+   
         self.sent_handshake = False
         self.received_handshake = False
 
         self.buffer = b''
-        self.bitfield = bitstring.BitArray(torrent.num_pieces)
+
+        #evil bit hack - rounds up to next multiple of 8
+        self.bitfield = bitstring.BitArray(((torrent.num_pieces + 7) >> 3) << 3)
 
         self.am_choking = True
         self.am_interested = False
@@ -17,6 +19,8 @@ class Peer:
         self.peer_interested = False
 
         self.request = False
+        self.requested = []
 
     def __eq__(self, obj):
         return self.address == obj
+    

--- a/peer.py
+++ b/peer.py
@@ -18,7 +18,6 @@ class Peer:
         self.peer_choking = True
         self.peer_interested = False
 
-        self.request = False
         self.requested = []
 
     def __eq__(self, obj):

--- a/torrent.py
+++ b/torrent.py
@@ -13,6 +13,7 @@ class Torrent:
         self.num_pieces = 0
         self.blocks_per_piece = 0
         self.blocks_per_final_piece = 0
+        self.final_piece_size = 0
         self.is_multi = False
         self.info_hash = None
 
@@ -36,9 +37,9 @@ class Torrent:
 
         self.num_pieces = math.ceil(self.length / self.data['info']['piece length'])
         self.blocks_per_piece = math.ceil(self.data['info']['piece length'] / BLOCK_SIZE)
-        
-        final_piece_size = self.length - (self.num_pieces-1)*self.data['info']['piece length']
-        self.blocks_per_final_piece = math.ceil(final_piece_size / BLOCK_SIZE)
+
+        self.final_piece_size = self.length - (self.num_pieces-1)*self.data['info']['piece length']
+        self.blocks_per_final_piece = math.ceil(self.final_piece_size / BLOCK_SIZE)
 
 
     def get_multifile_length(self):


### PR DESCRIPTION
Re-Request blocks:
-------------------------
upon dropping a connection, re-request all outstanding blocks
-fixed related issue with incorrect message lengths for bitfield and piece

Performance Improvements:
-----------------------------------
-check if a peer actually has a piece we need before sending interested
-use bitfields to find available blocks in `select_block`, instead of looping through entire list
-send multiple (currently 6) request messages per TCP message to reduce overhead

Misc Improvements:
------
-move `get_peer_from_socket` to client.py
-handle non-compact peer lists in tracker response
-reduce backoff factor in http requests to avoid long wait for tracker response
-move `blocks_per_piece`, `blocks_per_final_piece`, and `final_piece_length` to `Torrent` class
