### PR TITLE
implement request queue

### DIFF
--- a/client.py
+++ b/client.py
@@ -143,7 +143,7 @@ class Client:
     def drop_connection(self, peer_socket, connected):
         connected.remove(peer_socket)
         peer = self.get_peer_from_socket(peer_socket)
-        self.file_handler.reset_pieces(peer)
+        self.msg_handler.reset_pieces(peer)
 
     def get_peer_from_socket(self, socket):
         peer_ip = socket.getpeername()

--- a/filehandler.py
+++ b/filehandler.py
@@ -67,27 +67,6 @@ class FileHandler:
         #resulting bitfield represents pieces we don't have, but peer does have
         return not ((self.bitfield ^ peer.bitfield) & peer.bitfield).all(False)
     
-    def select_block(self, peer):
-
-        find_pieces = ((self.bitfield ^ peer.bitfield) & peer.bitfield).findall('0b1')
-        
-        for piece_index in find_pieces:
-
-            find_block = self.blocks_requested[piece_index].find('0b0')
-
-            if len(find_block) > 0:
-                block_index = find_block[0]
-                self.blocks_requested[piece_index][block_index] = True
-                return (piece_index, block_index)
-
-        return ()
-    
-    def reset_pieces(self, peer):
-        #re-request outstanding pieces
-        for indices in peer.requested:
-            piece = indices[0]
-            block = indices[1]
-            self.blocks_requested[piece][block] = self.blocks_received[piece][block]
 
 
     


### PR DESCRIPTION
Request Queue
-------------------
-replace `select_block` method with a queue of requests
-on startup, insert indices of each piece/block into request queue
-when re-requesting blocks, just insert back into the queue
-simplifies block selection and avoids a search of the block list each time
